### PR TITLE
feat: support explicit dispatch in agent sandboxes

### DIFF
--- a/templates.yaml
+++ b/templates.yaml
@@ -39,7 +39,7 @@
     License: "Apache-2.0"
 
 - name: "agent-starter-react"
-  display_name: "Next.js Voice Agent"
+  display_name: "Web Voice Agent"
   desc: "A starter app for Next.js, featuring a flexible voice AI frontend"
   url: "https://github.com/livekit-examples/agent-starter-react"
   image: "https://raw.githubusercontent.com/livekit-examples/agent-starter-react/refs/heads/main/.github/assets/template-graphic.svg"
@@ -113,7 +113,7 @@
       default: "Start call"
     agentName:
       type: string
-      description: "Optional - dispatch only agents with this name"
+      description: "Set agent name to enable explicit dispatch"
 
 - name: "agent-starter-android"
   display_name: "Android Voice Agent"

--- a/templates.yaml
+++ b/templates.yaml
@@ -111,6 +111,9 @@
       type: string
       description: "Connection button label text"
       default: "Start call"
+    agentName:
+      type: string
+      description: "Optional - dispatch only agents with this name"
 
 - name: "agent-starter-android"
   display_name: "Android Voice Agent"
@@ -209,6 +212,10 @@
     Type: "Frontend"
     Tools: "Next.js, TypeScript, HTML, CSS"
     License: "Apache-2.0"
+  inputs:
+    agentName:
+      type: string
+      description: "Optional - dispatch only agents with this name"
 
 - name: "token-server"
   display_name: "Token server"


### PR DESCRIPTION
Adds `agentName` config field to agent `agent-starter-react` and `agent-starter-embed`.
See: https://github.com/livekit-examples/agent-starter-react/pull/251, https://github.com/livekit/cloud-api-server/pull/1255

Also changes `agent-starter-react` title to "Web Voice Agent" (https://linear.app/livekit/issue/DPRO-485/web-sandbox-should-be-called-web-voice-agent-not-nextjs-voice-agent)